### PR TITLE
Toelichting expand verwijst naar definitie _embedded

### DIFF
--- a/api-specificatie/common.yaml
+++ b/api-specificatie/common.yaml
@@ -50,7 +50,7 @@ components:
       name: expand
       in: query
       required: false
-      description: "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/master/features/expand.feature)"
+      description: "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/master/features/expand.feature). In de definitie van het antwoord kunt u bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden."
       schema:
         type: string
     fields:

--- a/api-specificatie/common.yaml
+++ b/api-specificatie/common.yaml
@@ -50,7 +50,7 @@ components:
       name: expand
       in: query
       required: false
-      description: "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/master/features/expand.feature). In de definitie van het antwoord kunt u bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden."
+      description: "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. In de definitie van het antwoord kun je bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden." Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/master/features/expand.feature).
       schema:
         type: string
     fields:


### PR DESCRIPTION
in de description van de expand parameter uitleg opgenomen over waar men kan zien welke gerelateerde resources embed kunnen worden.