### PR TITLE
fix: lint validatie opmerkingen

### DIFF
--- a/api-specificatie/common.yaml
+++ b/api-specificatie/common.yaml
@@ -1,4 +1,4 @@
-breaking openapi: '3.0.0'
+openapi: 3.0.0
 info:
   title: Generieke componenten voor Haal Centraal APIs
   version: '1.1.0'
@@ -156,7 +156,7 @@ components:
           schema:
             $ref: "#/components/schemas/BadRequestFoutbericht"
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1
             title: Ten minste één parameter moet worden opgegeven.
             status: 400
             detail: The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.
@@ -177,7 +177,7 @@ components:
           schema:
             $ref: "#/components/schemas/Foutbericht"
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
             title: Niet correct geauthenticeerd.
             status: 401
             detail: The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.
@@ -193,7 +193,7 @@ components:
           schema:
             $ref: "#/components/schemas/Foutbericht"
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
             title: U bent niet geautoriseerd voor deze operatie.
             status: 403
             detail: The server understood the request, but is refusing to fulfill it.
@@ -209,7 +209,7 @@ components:
           schema:
             $ref: "#/components/schemas/Foutbericht"
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5
             title: Opgevraagde resource bestaat niet.
             status: 404
             detail: The server has not found anything matching the Request-URI.
@@ -225,7 +225,7 @@ components:
           schema:
             $ref: "#/components/schemas/Foutbericht"
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7
             title: Gevraagde contenttype wordt niet ondersteund.
             status: 406
             detail: The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request
@@ -241,7 +241,7 @@ components:
           schema:
             $ref: "#/components/schemas/Foutbericht"
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.10
             title: Conflict
             status: 409
             detail: The request could not be completed due to a conflict with the current state of the resource
@@ -257,7 +257,7 @@ components:
           schema:
             $ref: "#/components/schemas/Foutbericht"
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.11
             title: Gone
             status: 410
             detail: The request could not be completed due to a conflict with the current state of the resource
@@ -273,7 +273,7 @@ components:
           schema:
             $ref: "#/components/schemas/Foutbericht"
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.13 412 Precondition Failed
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.13
             title: Precondition Failed
             status: 412
             detail: The precondition given in one or more of the request-header fields evaluated to false when it was tested on the server.
@@ -289,7 +289,7 @@ components:
           schema:
             $ref: "#/components/schemas/Foutbericht"
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16
             title: Unsupported Media Type
             status: 415
             detail: The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.
@@ -305,7 +305,7 @@ components:
           schema:
             $ref: "#/components/schemas/Foutbericht"
           example:
-            type: 'https://tools.ietf.org/html/rfc4918#section-11.2'
+            type: https://tools.ietf.org/html/rfc4918#section-11.2
             title: Aanvraag kan niet verwerkt worden
             status: 422
             detail: The server understands the content type of the request entity and the syntax of the request entity is correct but was unable to process the contained instructions.
@@ -337,7 +337,7 @@ components:
           schema:
             $ref: "#/components/schemas/Foutbericht"
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
             title: Interne server fout.
             status: 500
             detail: The server encountered an unexpected condition which prevented it from fulfilling the request.
@@ -353,7 +353,7 @@ components:
           schema:
             $ref: "#/components/schemas/Foutbericht"
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.2 501 Not Implemented
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2
             title: Not Implemented
             status: 501
             detail: The server does not support the functionality required to fulfill the request.
@@ -369,7 +369,7 @@ components:
           schema:
             $ref: "#/components/schemas/Foutbericht"
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
             title: Bronservice {bron} is tijdelijk niet beschikbaar.
             status: 503
             detail: The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.


### PR DESCRIPTION
- tekst 'breaking' verwijderd. 'breaking openapi' is geen bekende format
- urls naar status code beschrijvingen zijn niet valide. Als je het copy en paste in de browser kom je niet op de goede sectie