### PR TITLE
Fix: inline object definities

### DIFF
--- a/api-specificatie/common.yaml
+++ b/api-specificatie/common.yaml
@@ -3,14 +3,6 @@ info:
   title: Generieke componenten voor Haal Centraal APIs
   description: |
     De definitie van generieke components die worden gebruikt door de Haal Centraal APIs
-
-    DatumOnvolledig is toegevoegd als CamelCase tegenhanger van Datum_onvolledig (deprecated).
-    Deze constructie (t.b.v. evolvability) zorgt ervoor dat
-
-    - je geen duplicaat krijgt van een schema en
-    - maakt het mogelijk voor een provider om wel al te linken naar deze versie (voor bijvoorbeeld de nieuwe HalPaginationLinks en HalPaginationLinksMetLast schemas) zonder Datum_onvolledig ook te moeten vervangen.
-      Deze constructie is wel een overtreding van DD5.21 (een allOf zonder extra properties toevoegingen).
-
   version: '1.1.0'
   contact:
     name: Haal Centraal Common
@@ -534,7 +526,7 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/InvalidParams"
-    DatumOnvolledig:
+    Datum_onvolledig:
       type: "object"
       description: "Gegevens over de datums die mogelijk niet volledig zijn, maar\
         \ waarvan de bekende gedeeltes wel moeten kunnen worden uitgewisseld. Als\
@@ -570,10 +562,6 @@ components:
           minimum: 1
           maximum: 12
           example: 5
-    Datum_onvolledig:
-      deprecated: true
-      allOf:
-        - $ref: "#/components/schemas/DatumOnvolledig"
     Waardelijst:
       type: "object"
       description: "Generieke waardelijst met waarden om een code en omschrijving op te nemen."

--- a/api-specificatie/common.yaml
+++ b/api-specificatie/common.yaml
@@ -1,7 +1,13 @@
 openapi: 3.0.0
 info:
   title: Generieke componenten voor Haal Centraal APIs
+  description: |
+    De definitie van generieke components die worden gebruikt door de Haal Centraal APIs
   version: '1.1.0'
+  contact:
+    name: Haal Centraal Common
+    url: https://github.com/VNG-Realisatie/Haal-Centraal-Common
+paths: {}
 components:
   headers:
     api_version:
@@ -407,63 +413,63 @@ components:
         self:
           $ref: "#/components/schemas/HalLink"
     HalPaginationLinks:
+      description: |
+        HalPaginationLinks bevat de link properties die nodig zijn om te kunnen navigeren in een collectie:
+
+        - first: uri voor het opvragen van de eerste pagina van deze collectie
+        - previous: uri voor het opvragen van de vorige pagina van deze collectie
+        - next: uri voor het opvragen van de volgende pagina van deze collectie
       allOf:
       - $ref: "#/components/schemas/HalCollectionLinks"
-      - type: "object"
+      - type: object
         properties:
           first:
-            type: "object"
-            description: "uri voor het opvragen van de eerste pagina van deze collectie"
-            properties:
-              href:
-                type: "string"
-                example: "/resourcenaam?page=1"
-              templated:
-                type: boolean
-              title:
-                type: "string"
-                example: "Eerste pagina"
+            $ref: "#/components/schemas/HalLink"
           previous:
-            type: "object"
-            description: "uri voor het opvragen van de vorige pagina van deze collectie"
-            properties:
-              href:
-                type: "string"
-                example: "/resourcenaam?page=3"
-              templated:
-                type: boolean
-              title:
-                type: "string"
-                example: "Vorige pagina"
+            $ref: "#/components/schemas/HalLink"
           next:
-            type: "object"
-            description: "uri voor het opvragen van de volgende pagina van deze collectie"
-            properties:
-              href:
-                type: "string"
-                example: "/resourcenaam?page=5"
-              templated:
-                type: boolean
-              title:
-                type: "string"
-                example: "Volgende pagina"
+            $ref: "#/components/schemas/HalLink"
+      example:
+        self:
+          href: /resourcenaam?page=4
+        first:
+          href: /resourcenaam?page=1
+          title: Eerste pagina
+        previous:
+          href: /resourcenaam?page=3
+          title: Vorige pagina
+        next:
+          href: /resourcenaam?page=5
+          title: Volgende pagina
     HalPaginationLinksMetLast:
+      description: |
+        HalPaginationLinks bevat de link properties die nodig zijn om te kunnen navigeren in een eindige collectie:
+
+        - first: uri voor het opvragen van de eerste pagina van deze collectie
+        - previous: uri voor het opvragen van de vorige pagina van deze collectie
+        - next: uri voor het opvragen van de volgende pagina van deze collectie
+        - last: uri voor het opvragen van de laatste pagina van deze collectie
       allOf:
       - $ref: "#/components/schemas/HalPaginationLinks"
-      - type: "object"
+      - type: object
         properties:
           last:
-            type: "object"
-            description: "uri voor het opvragen van de laatste pagina van deze collectie"
-            properties:
-              href:
-                type: "string"
-                example: "/resourcenaam?page=8"
-              templated:
-                type: boolean
-              title:
-                type: "string"
-                example: "Laatste pagina"
+            $ref: "#/components/schemas/HalLink"
+      example:
+        self:
+          href: /resourcenaam?page=4
+        first:
+          href: /resourcenaam?page=1
+          title: Eerste pagina
+        previous:
+          href: /resourcenaam?page=3
+          title: Vorige pagina
+        next:
+          href: /resourcenaam?page=5
+          title: Volgende pagina
+        last:
+          href: /resourcenaam?page=8
+          title: Laatste pagina
     Foutbericht:
       type: object
       description: Terugmelding bij een fout. JSON representatie in lijn met [RFC7807](https://tools.ietf.org/html/rfc7807).
@@ -556,6 +562,9 @@ components:
           minimum: 1
           maximum: 12
           example: 5
+    DatumOnvolledig:
+      allOf:
+        - $ref: "#/components/schemas/Datum_onvolledig"
     Waardelijst:
       type: "object"
       description: "Generieke waardelijst met waarden om een code en omschrijving op te nemen."

--- a/api-specificatie/common.yaml
+++ b/api-specificatie/common.yaml
@@ -409,6 +409,8 @@ components:
          type: string
     HalCollectionLinks:
       type: object
+      description: |
+        HalCollectionLinks bevat de self link die elke HAL Resource minimaal moet hebben in zijn _links property
       properties:
         self:
           $ref: "#/components/schemas/HalLink"
@@ -443,7 +445,7 @@ components:
           title: Volgende pagina
     HalPaginationLinksMetLast:
       description: |
-        HalPaginationLinks bevat de link properties die nodig zijn om te kunnen navigeren in een eindige collectie:
+        HalPaginationLinksMetLast bevat de link properties die nodig zijn om te kunnen navigeren in een eindige collectie:
 
         - first: uri voor het opvragen van de eerste pagina van deze collectie
         - previous: uri voor het opvragen van de vorige pagina van deze collectie

--- a/api-specificatie/common.yaml
+++ b/api-specificatie/common.yaml
@@ -3,6 +3,14 @@ info:
   title: Generieke componenten voor Haal Centraal APIs
   description: |
     De definitie van generieke components die worden gebruikt door de Haal Centraal APIs
+
+    DatumOnvolledig is toegevoegd als CamelCase tegenhanger van Datum_onvolledig (deprecated).
+    Deze constructie (t.b.v. evolvability) zorgt ervoor dat
+
+    - je geen duplicaat krijgt van een schema en
+    - maakt het mogelijk voor een provider om wel al te linken naar deze versie (voor bijvoorbeeld de nieuwe HalPaginationLinks en HalPaginationLinksMetLast schemas) zonder Datum_onvolledig ook te moeten vervangen.
+      Deze constructie is wel een overtreding van DD5.21 (een allOf zonder extra properties toevoegingen).
+
   version: '1.1.0'
   contact:
     name: Haal Centraal Common
@@ -526,7 +534,7 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/InvalidParams"
-    Datum_onvolledig:
+    DatumOnvolledig:
       type: "object"
       description: "Gegevens over de datums die mogelijk niet volledig zijn, maar\
         \ waarvan de bekende gedeeltes wel moeten kunnen worden uitgewisseld. Als\
@@ -562,9 +570,10 @@ components:
           minimum: 1
           maximum: 12
           example: 5
-    DatumOnvolledig:
+    Datum_onvolledig:
+      deprecated: true
       allOf:
-        - $ref: "#/components/schemas/Datum_onvolledig"
+        - $ref: "#/components/schemas/DatumOnvolledig"
     Waardelijst:
       type: "object"
       description: "Generieke waardelijst met waarden om een code en omschrijving op te nemen."

--- a/api-specificatie/common.yaml
+++ b/api-specificatie/common.yaml
@@ -570,7 +570,7 @@ components:
     Datum_onvolledig:
       default: true
       allOf:
-          - $ref: "#/components/schemas/Datum_onvolledig"
+          - $ref: "#/components/schemas/DatumOnvolledig"
     Waardelijst:
       type: "object"
       description: "Generieke waardelijst met waarden om een code en omschrijving op te nemen."

--- a/api-specificatie/common.yaml
+++ b/api-specificatie/common.yaml
@@ -568,7 +568,7 @@ components:
           maximum: 12
           example: 5
     Datum_onvolledig:
-      default: true
+      deprecated: true
       allOf:
           - $ref: "#/components/schemas/DatumOnvolledig"
     Waardelijst:

--- a/api-specificatie/common.yaml
+++ b/api-specificatie/common.yaml
@@ -3,6 +3,12 @@ info:
   title: Generieke componenten voor Haal Centraal APIs
   description: |
     De definitie van generieke components die worden gebruikt door de Haal Centraal APIs
+
+    DatumOnvolledig is toegevoegd als CamelCase tegenhanger van Datum_onvolledig (deprecated).
+    Deze constructie (t.b.v. evolvability) zorgt ervoor dat
+    - je geen duplicaat krijgt van een schema en
+    - maakt het mogelijk voor een provider om wel al te linken naar deze versie (voor bijvoorbeeld de nieuwe HalPaginationLinks en HalPaginationLinksMetLast schemas) zonder Datum_onvolledig ook te moeten vervangen.
+      Deze constructie is wel een overtreding van DD5.21 (een allOf zonder extra properties toevoegingen).
   version: '1.1.0'
   contact:
     name: Haal Centraal Common
@@ -531,7 +537,7 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/InvalidParams"
-    Datum_onvolledig:
+    DatumOnvolledig:
       type: "object"
       description: "Constructie voor het uitwisselen van datums die wel of niet volledig bekend zijn."
       properties:
@@ -561,6 +567,10 @@ components:
           minimum: 1
           maximum: 12
           example: 5
+    Datum_onvolledig:
+      default: true
+      allOf:
+          - $ref: "#/components/schemas/Datum_onvolledig"
     Waardelijst:
       type: "object"
       description: "Generieke waardelijst met waarden om een code en omschrijving op te nemen."


### PR DESCRIPTION
- Description HalPaginationLinks en HalPaginationLinksMetLast toegevoegd om de navigatie links te documenteren
- DatumOnvolledig toegevoegd als CamelCase tegenhanger van Datum_onvolledig. De constructie die hier is gebruikt (t.b.v. m.i. evolvability) zorgt ervoor dat
  -  je geen duplicaat krijgt van een schema en
  - maakt het mogelijk voor een provider om wel al te linken naar deze versie (voor bijvoorbeeld de nieuwe HalPaginationLinks en HalPaginationLinksMetLast schemas) zonder Datum_onvolledig ook te moeten vervangen. Deze constructie is wel een overtreding van DD5.21 (een allOf zonder extra properties toevoegingen).