### PR TITLE
Onderscheid tussen basisfunctionaliteit en aanvullende functionaliteit voor de fields parameter

### DIFF
--- a/features/fields.feature
+++ b/features/fields.feature
@@ -192,7 +192,7 @@ Functionaliteit: Aanpasbare representatie met de fields parameter
     ```
 
 
-    Voor sommige API's kan besloten worden extra functionaliteit te bieden bij het invullen van de fields paramter. Bij de API specificaties en/of features is dan aangegeven dat de uitgebreide variant van de fields functionaliteit wordt geborden.
+    Voor sommige API's kan besloten worden extra functionaliteit te bieden bij het invullen van de fields paramter. Bij de API specificaties en/of features is dan aangegeven dat de uitgebreide variant van de fields functionaliteit wordt geboden.
     Deze functionaliteit maakt het mogelijk velden in groepen te vragen door alleen de naam van de property op te geven, of een deel van het pad, niet het hele pad ervoor. Dit kan nuttig zijn om de lengte van de waarde in fields te beperken.
 
     Met de fields parameter kan een gevraagd veld worden aangeduid met:

--- a/features/fields.feature
+++ b/features/fields.feature
@@ -51,63 +51,38 @@ Functionaliteit: Aanpasbare representatie met de fields parameter
 
   Scenario: Slechts één enkel attribuut wordt gevraagd
     Als een ingeschreven persoon wordt geraadpleegd met fields=geslachtsaanduiding
-    Dan wordt attribuut geslachtsaanduiding teruggegeven
-    En wordt attribuut _links.self teruggegeven
-    En wordt geen enkel ander attribuut dan geslachtsaanduiding teruggegeven
-    En bevat _links geen ander attribuut dan self
-    En wordt er geen gerelateerde sub-resource teruggegeven in _embedded
+    Dan worden alleen attributen geslachtsaanduiding en _links teruggegeven
+    En bevat _links alleen attribuut self
 
   Scenario: Meerdere attributen worden gevraagd
     Als een ingeschreven persoon wordt geraadpleegd met fields=burgerservicenummer,burgerlijkeStaat,geslachtsaanduiding
-    Dan wordt attribuut burgerservicenummer teruggegeven
-    En wordt attribuut burgerlijkeStaat teruggegeven
-    En wordt attribuut geslachtsaanduiding teruggegeven
-    En wordt attribuut _links.self teruggegeven
-    En wordt geen enkel ander attribuut dan burgerservicenummer, burgerlijkeStaat, geslachtsaanduiding en _links.self teruggegeven
-    En bevat _links geen ander attribuut dan self
-    En wordt er geen gerelateerde sub-resource teruggegeven in _embedded
+    Dan worden alleen attributen burgerservicenummer, burgerlijkeStaat, geslachtsaanduiding en _links teruggegeven
+    En bevat _links alleen attribuut self
 
   Scenario: Hele groep wordt gevraagd
     Gegeven de te raadplegen persoon heeft voornamen, geslachtsnaam en voorvoegsel
     Als een ingeschreven persoon wordt geraadpleegd met fields=burgerservicenummer,naam
-    Dan wordt attribuut burgerservicenummer teruggegeven
-    En wordt attribuut naam.voornamen teruggegeven
-    En wordt attribuut naam.geslachtsnaam teruggegeven
-    En wordt attribuut naam.voorvoegsel teruggegeven
-    En wordt attribuut _links.self teruggegeven
-    En wordt geen enkel ander attribuut dan burgerservicenummer, naam en _links teruggegeven
-    En bevat _links geen ander attribuut dan self
-    En wordt er geen gerelateerde sub-resource teruggegeven in _embedded
+    Dan worden alleen attributen burgerservicenummer, naam en _links teruggegeven
+    En bevat _links alleen attribuut self
 
   Scenario: Een of enkele attributen binnen een groep worden gevraagd
     Als een ingeschreven persoon wordt geraadpleegd met fields=naam.aanschrijfwijze,naam.voornamen
-    Dan wordt attribuut naam.aanschrijfwijze teruggegeven
-    En wordt attribuut naam.voornamen teruggegeven
-    En wordt attribuut _links.self teruggegeven
-    En bevat naam geen ander attribuut dan aanschrijfwijze en voornamen
-    En bevat _links geen ander attribuut dan self
-    En wordt geen enkel ander attribuut dan naam en _links teruggegeven
-    En wordt er geen gerelateerde sub-resource teruggegeven in _embedded
+    Dan worden alleen attributen naam en _links teruggegeven
+    En bevat naam alleen attributen aanschrijfwijze en voornamen
+    En bevat _links alleen attribuut self
 
   Scenario: Relaties (links) vragen (en beperken) in het antwoord
     Gegeven de te raadplegen persoon heeft een actuele partner(partnerschap of huwelijk), ouders en kinderen
     Als een ingeschreven persoon wordt geraadpleegd met fields=burgerservicenummer,naam,_links.partners
-    Dan wordt attribuut _links.partners teruggegeven
-    En wordt attribuut burgerservicenummer teruggegeven
-    En wordt attribuut naam.voornamen teruggegeven
-    En wordt attribuut naam.geslachtsnaam teruggegeven
-    En wordt attribuut naam.voorvoegsel teruggegeven
-    En wordt attribuut _links.self teruggegeven
-    En wordt in _links geen enkel ander attribuut dan self en partners teruggegeven
-    En wordt er geen gerelateerde sub-resource teruggegeven in _embedded
+    Dan worden alleen attributen burgerservicenummer, naam en _links teruggegeven
+    En bevat _links alleen attributen self en partners
 
   Scenario: Gebruik van de fields parameter heeft geen invloed op embedded sub-resources
     Als een ingeschreven persoon wordt geraadpleegd met fields=geboorte.land&expand=kinderen
-    Dan wordt attribuut geboorte.land teruggegeven
-    En wordt attribuut _links.self teruggegeven
-    En wordt in _links geen enkel ander attribuut dan self teruggegeven
-    En wordt geen enkel ander attribuut dan geboorte, _links en _embedded teruggegeven
-    En wordt attribuut _embedded.kinderen teruggegeven
+    Dan worden alleen attributen geboorte, _links en _embedded teruggegeven
+    En bevat geboorte alleen attribuut land
+    En bevat _links alleen attribuut self
+    En bevat _embedded alleen attribuut kinderen
     En bevat elk voorkomen van _embedded.kinderen attribuut burgerservicenummer met een waarde
     En bevat elk voorkomen van_embedded.kinderen attribuut naam met een waarde
     En bevat elk voorkomen van_embedded.kinderen attribuut geboorte.datum met een waarde
@@ -116,19 +91,17 @@ Functionaliteit: Aanpasbare representatie met de fields parameter
 
   Scenario: Gebruik van de expand parameter heeft geen invloed op de inhoud van de resource
     Als een ingeschreven persoon wordt geraadpleegd met fields=_links.partners&expand=kinderen
-    Dan wordt attribuut _links.partners teruggegeven
-    En wordt attribuut _links.self teruggegeven
-    En bevat _links niet attribuut kinderen
-    En wordt in _links geen enkel ander attribuut dan self en partners teruggegeven
-    En wordt attribuut _embedded.kinderen teruggegeven
-    En wordt in _embedded geen enkel ander attribuut dan kinderen teruggegeven
-    En wordt geen enkel ander attribuut dan _links en _embedded teruggegeven
+    Dan worden alleen attributen _links en _embedded teruggegeven
+    En bevat _links alleen attributen self en partners
+    En bevat _embedded alleen attribuut kinderen
 
   Scenario: Vragen van specifieke velden met de expand parameter heeft geen invloed op de inhoud van de resource, alleen op de inhoud van de embedded subresource
     Als een ingeschreven persoon wordt geraadpleegd met expand=kinderen.naam.voornamen
     Dan bevat elk voorkomen van_embedded.kinderen attribuut naam.voornamen met een waarde
     En bevat elk voorkomen van_embedded.kinderen attribuut _links.self met een waarde
-    En wordt in elk voorkomen van _embedded.kinderen geen enkel ander attribuut dan naam.voornamen en _links.self teruggegeven
+    En bevat elk voorkomen van _embedded.kinderen alleen attributen naam en _links
+    En bevat in elk voorkomen van _embedded.kinderen naam alleen attribuut voornamen
+    En bevat in elk voorkomen van _embedded.kinderen _links alleen attribuut self
     En wordt attribuut burgerservicenummer teruggegeven
     En wordt attribuut naam.voornamen teruggegeven
     En wordt attribuut naam.geslachtsnaam teruggegeven
@@ -136,7 +109,6 @@ Functionaliteit: Aanpasbare representatie met de fields parameter
     En wordt attribuut geboorte teruggegeven
     En wordt attribuut _links.self teruggegeven
     En wordt attribuut _links.kinderen teruggegeven
-    En wordt in _embedded geen enkel ander attribuut dan kinderen teruggegeven
 
   Scenario: Lege fields parameter geeft alle attributen
     Als een ingeschreven persoon wordt geraadpleegd met fields=
@@ -162,7 +134,7 @@ Functionaliteit: Aanpasbare representatie met de fields parameter
     En is in het antwoord attribuut geboorte.plaats niet aanwezig
     En is in het antwoord attribuut geboorte.land niet aanwezig
     En wordt attribuut _links.self teruggegeven
-    En wordt in _links geen enkel ander attribuut dan self teruggegeven
+    En bevat _links alleen attribuut self
 
   Scenario: Fields vraagt specifiek om een gegeven waarvoor deze niet geautoriseerd is
     Gegeven de gebruiker is geautoriseerd voor geboortedatum
@@ -172,12 +144,14 @@ Functionaliteit: Aanpasbare representatie met de fields parameter
     En is in het antwoord attribuut geboorte.plaats niet aanwezig
     En is in het antwoord attribuut geboorte.land niet aanwezig
     En wordt attribuut _links.self teruggegeven
-    En wordt in _links geen enkel ander attribuut dan self teruggegeven
 
   Scenario: Fields bevat attributen die bij de geraadpleegde persoon geen waarde hebben
     Gegeven de te raadplegen persoon verblijft in het buitenland
     Als een ingeschreven persoon wordt geraadpleegd met fields=verblijfplaats.postcode,verblijfplaats.huisnummer
-    Dan wordt attribuut verblijfplaats.adresregel1 teruggegeven
+    Dan wordt alleen attribuut _links teruggegeven
+    En bevat _links alleen attribuut self
+    En is in het antwoord attribuut verblijfplaats.adresregel1 niet aanwezig
+    En is in het antwoord attribuut verblijfplaats.land niet aanwezig
     En is in het antwoord attribuut verblijfplaats.postcode niet aanwezig
     En is in het antwoord attribuut verblijfplaats.huisnummer niet aanwezig
 

--- a/features/fields.feature
+++ b/features/fields.feature
@@ -25,17 +25,12 @@ Functionaliteit: Aanpasbare representatie met de fields parameter
   Attributen binnen een groep kunnen ook individueel worden bevraagd. De dot-notatie wordt gebruikt om specifieke attributen van een groep te selecteren. Bijvoorbeeld de voornamen, geboortedatum en geboorteplaats van een persoon kunnen worden opgevraagd via fields=naam.voornamen,geboorte.datum,geboorte.plaats.
 
   Met de fields parameter kan ook worden aangegeven welke relaties moeten worden opgenomen. Dit betreft de links (in _links) die verwijzen (uri) naar de betreffende gerelateerde resource. Wanneer de fields parameter is meegegeven in het request worden alleen die relaties teruggegeven die zijn gevraagd in de fields parameter.
-  In de fields parameter kan de relatie worden gevraagd door de relatienaam op te nemen al dan niet voorafgegaan door HAL-element _links.
-  Bijvoorbeeld de links naar de kinderen van een persoon worden teruggegeven bij fields=burgerservicenummer,naam,kinderen. In dat geval worden andere relaties, zoals ouders en partners niet opgenomen in het antwoord (in _links). Hetzelfde antwoord kan worden verkregen met fields=burgerservicenummer,naam,_links.kinderen.
-  Wanneer de resource een property bevat met exact dezelfde naam als een van de properties in _links, dan wordt bij het vragen van deze property alleen het property uit de resource teruggegeven en niet het gelijknamige property uit _links. In dat geval kan de gelijknamige relatie alleen worden gevraagd door _links voor de linkpropertynaam te plaatsen.
+  In de fields parameter kan de relatie worden gevraagd door de relatienaam op te nemen, voorafgegaan door HAL-element _links.
+  Bijvoorbeeld de links naar de kinderen van een persoon worden teruggegeven bij fields=burgerservicenummer,naam,_links.kinderen. In dat geval worden andere relaties, zoals ouders en partners niet opgenomen in het antwoord (in _links).
 
-  De self-link in _links (JSON HAL) wordt altijd teruggegeven in het antwoord. Deze hoeft (en mag) niet te worden opgenomen in de fields parameter.
+  De self-link in _links (JSON HAL) wordt altijd teruggegeven in het antwoord. Deze hoeft niet te worden opgenomen in de fields parameter en zal altijd worden opgenomen, ook wanneer alleen andere velden zijn gevraagd met de fields parameter.
 
-  Attributen inOnderzoek worden meegegeven wanneer gevraagde attributen in onderzoek zijn. Zie in_onderzoek.feature voor uitleg wanneer attributen in onderzoek zijn.
-
-  Attribuut indicatieGeheim wordt altijd meegegeven wanneer deze een waarde anders dan 0 heeft.
-
-  Attributen datumOpschortingBijhouding en redenOpschortingBijhouding worden altijd meegegeven wanneer deze een waarde hebben.
+  In een API kunnen ook andere velden verplicht worden opgenomen, al dan niet afhankelijk van de gevraagde gegevens en waarden, omdat de gebruiker die echt moet weten. Bijvoorbeeld geheimhoudingPersoonsgegevens, mogelijkOnjuist en inOnderzoek.
 
   Gebruik van de fields parameter heeft geen invloed op eventueel meegeladen sub-resources. Dat wordt gestuurd via de expand parameter. Dus wanneer er specifieke attributen van een sub-resource gewenst zijn, worden die opgesomd in de expand parameter. Bijvoorbeeld expand=partners.geslachtsnaam. Zie verder expand.feature
 
@@ -45,11 +40,8 @@ Functionaliteit: Aanpasbare representatie met de fields parameter
 
   In de fields-parameter moeten attribuutnamen exact zo worden geschreven als voor de resource-response gedefinieerd. Dit is case sensitive. Bijvoorbeeld fields=BURGERSERVICENUMMER levert een foutmelding, want dat attribuut bestaat niet (attribuut burgerservicenummer bestaat wel).
 
+  Bovenop deze basisfunctionaliteit voor fields kan voor een API worden besloten meer uitgebreide functionaliteit voor fields te ondersteunen. Deze wordt onderaan deze feature uitgewerkt.
 
-  Achtergrond:
-    Gegeven de registratie ingeschreven personen kent zoals beschreven in testdata.csv
-    En in onderstaande scenario's wordt de expand parameter niet gebruikt, tenzij expliciet aangegeven
-    En de gebruiker geautoriseerd is voor gevraagde gegevens, tenzij expliciet anders aangegeven
 
   Scenario: De fields-parameter is niet opgenomen
     Als een ingeschreven persoon wordt geraadpleegd zonder fields-parameter
@@ -60,9 +52,9 @@ Functionaliteit: Aanpasbare representatie met de fields parameter
   Scenario: Slechts één enkel attribuut wordt gevraagd
     Als een ingeschreven persoon wordt geraadpleegd met fields=geslachtsaanduiding
     Dan wordt attribuut geslachtsaanduiding teruggegeven
-    En wordt geen enkel ander attribuut dan geslachtsaanduiding teruggegeven
-    En wordt geen enkele relatie van de resource in _links teruggegeven
     En wordt attribuut _links.self teruggegeven
+    En wordt geen enkel ander attribuut dan geslachtsaanduiding teruggegeven
+    En bevat _links geen ander attribuut dan self
     En wordt er geen gerelateerde sub-resource teruggegeven in _embedded
 
   Scenario: Meerdere attributen worden gevraagd
@@ -70,9 +62,9 @@ Functionaliteit: Aanpasbare representatie met de fields parameter
     Dan wordt attribuut burgerservicenummer teruggegeven
     En wordt attribuut burgerlijkeStaat teruggegeven
     En wordt attribuut geslachtsaanduiding teruggegeven
-    En wordt geen enkel ander attribuut dan burgerservicenummer, burgerlijkeStaat en geslachtsaanduiding teruggegeven
-    En wordt geen enkele relatie van de resource in _links teruggegeven
     En wordt attribuut _links.self teruggegeven
+    En wordt geen enkel ander attribuut dan burgerservicenummer, burgerlijkeStaat, geslachtsaanduiding en _links.self teruggegeven
+    En bevat _links geen ander attribuut dan self
     En wordt er geen gerelateerde sub-resource teruggegeven in _embedded
 
   Scenario: Hele groep wordt gevraagd
@@ -82,33 +74,24 @@ Functionaliteit: Aanpasbare representatie met de fields parameter
     En wordt attribuut naam.voornamen teruggegeven
     En wordt attribuut naam.geslachtsnaam teruggegeven
     En wordt attribuut naam.voorvoegsel teruggegeven
-    En wordt geen enkel ander attribuut dan burgerservicenummer en naam teruggegeven
-    En wordt geen enkele relatie van de resource in _links teruggegeven
     En wordt attribuut _links.self teruggegeven
+    En wordt geen enkel ander attribuut dan burgerservicenummer, naam en _links teruggegeven
+    En bevat _links geen ander attribuut dan self
     En wordt er geen gerelateerde sub-resource teruggegeven in _embedded
 
   Scenario: Een of enkele attributen binnen een groep worden gevraagd
-    Als een ingeschreven persoon wordt geraadpleegd met fields=naam.aanschrijfwijze
+    Als een ingeschreven persoon wordt geraadpleegd met fields=naam.aanschrijfwijze,naam.voornamen
     Dan wordt attribuut naam.aanschrijfwijze teruggegeven
-    En wordt in naam geen enkel ander attribuut dan aanschrijfwijze teruggegeven
+    En wordt attribuut naam.voornamen teruggegeven
+    En wordt attribuut _links.self teruggegeven
+    En bevat naam geen ander attribuut dan aanschrijfwijze en voornamen
+    En bevat _links geen ander attribuut dan self
     En wordt geen enkel ander attribuut dan naam en _links teruggegeven
-    En wordt geen enkele relatie van de resource in _links teruggegeven
-    En wordt attribuut _links.self teruggegeven
-    En wordt er geen gerelateerde sub-resource teruggegeven in _embedded
-
-    Als een ingeschreven persoon wordt geraadpleegd met fields=naam.voorvoegsel,naam.geslachtsnaam
-    Dan wordt attribuut naam.geslachtsnaam teruggegeven
-    En wordt attribuut naam.voorvoegsel teruggegeven
-    En wordt in naam geen enkel ander attribuut dan voorvoegsel en geslachtsnaam teruggegeven
-    En wordt geen enkele relatie van de resource in _links teruggegeven
-    En wordt attribuut _links.self teruggegeven
     En wordt er geen gerelateerde sub-resource teruggegeven in _embedded
 
   Scenario: Relaties (links) vragen (en beperken) in het antwoord
     Gegeven de te raadplegen persoon heeft een actuele partner(partnerschap of huwelijk), ouders en kinderen
-    En de te raadplegen persoon heeft een BAG-adres (nummeraanduiding) als verblijfplaats
-
-    Als een ingeschreven persoon wordt geraadpleegd met fields=burgerservicenummer,naam,partners
+    Als een ingeschreven persoon wordt geraadpleegd met fields=burgerservicenummer,naam,_links.partners
     Dan wordt attribuut _links.partners teruggegeven
     En wordt attribuut burgerservicenummer teruggegeven
     En wordt attribuut naam.voornamen teruggegeven
@@ -116,63 +99,44 @@ Functionaliteit: Aanpasbare representatie met de fields parameter
     En wordt attribuut naam.voorvoegsel teruggegeven
     En wordt attribuut _links.self teruggegeven
     En wordt in _links geen enkel ander attribuut dan self en partners teruggegeven
-    En is elke link partners een geldige uri
-    En wordt er geen gerelateerde sub-resource teruggegeven in _embedded
-
-    Als een ingeschreven persoon wordt geraadpleegd met fields=burgerservicenummer,naam,ouders
-    Dan wordt attribuut _links.ouders teruggegeven
-    En wordt attribuut burgerservicenummer teruggegeven
-    En wordt attribuut naam.voornamen teruggegeven
-    En wordt attribuut naam.geslachtsnaam teruggegeven
-    En wordt attribuut naam.voorvoegsel teruggegeven
-    En wordt attribuut _links.self teruggegeven
-    En wordt in _links geen enkel ander attribuut dan self en ouders teruggegeven
-    En is elke link ouders een geldige uri
-    En wordt er geen gerelateerde sub-resource teruggegeven in _embedded
-
-    Als een ingeschreven persoon wordt geraadpleegd met fields=burgerservicenummer,naam,kinderen
-    Dan wordt attribuut _links.kinderen teruggegeven
-    En wordt attribuut burgerservicenummer teruggegeven
-    En wordt attribuut naam.voornamen teruggegeven
-    En wordt attribuut naam.geslachtsnaam teruggegeven
-    En wordt attribuut naam.voorvoegsel teruggegeven
-    En wordt attribuut _links.self teruggegeven
-    En wordt in _links geen enkel ander attribuut dan self en kinderen teruggegeven
-    En is elke link kinderen een geldige uri
-    En wordt er geen gerelateerde sub-resource teruggegeven in _embedded
-
-    Als een ingeschreven persoon wordt geraadpleegd met fields=burgerservicenummer,naam,partners,ouders
-    Dan wordt attribuut _links.partners teruggegeven
-    En wordt attribuut _links.ouders teruggegeven
-    En wordt attribuut burgerservicenummer teruggegeven
-    En wordt attribuut naam.voornamen teruggegeven
-    En wordt attribuut naam.geslachtsnaam teruggegeven
-    En wordt attribuut naam.voorvoegsel teruggegeven
-    En wordt attribuut _links.self teruggegeven
-    En wordt in _links geen enkel ander attribuut dan self, partners en ouders teruggegeven
-    En is elke link partners een geldige uri
-    En is elke link ouders een geldige uri
     En wordt er geen gerelateerde sub-resource teruggegeven in _embedded
 
   Scenario: Gebruik van de fields parameter heeft geen invloed op embedded sub-resources
-    Als een ingeschreven persoon wordt geraadpleegd met fields=partners&expand=kinderen
+    Als een ingeschreven persoon wordt geraadpleegd met fields=geboorte.land&expand=kinderen
+    Dan wordt attribuut geboorte.land teruggegeven
+    En wordt attribuut _links.self teruggegeven
+    En wordt in _links geen enkel ander attribuut dan self teruggegeven
+    En wordt geen enkel ander attribuut dan geboorte, _links en _embedded teruggegeven
+    En wordt attribuut _embedded.kinderen teruggegeven
+    En bevat elk voorkomen van _embedded.kinderen attribuut burgerservicenummer met een waarde
+    En bevat elk voorkomen van_embedded.kinderen attribuut naam met een waarde
+    En bevat elk voorkomen van_embedded.kinderen attribuut geboorte.datum met een waarde
+    En bevat elk voorkomen van_embedded.kinderen attribuut geboorte.plaats met een waarde
+    En bevat elk voorkomen van_embedded.kinderen attribuut geboorte.land met een waarde
+
+  Scenario: Gebruik van de expand parameter heeft geen invloed op de inhoud van de resource
+    Als een ingeschreven persoon wordt geraadpleegd met fields=_links.partners&expand=kinderen
     Dan wordt attribuut _links.partners teruggegeven
     En wordt attribuut _links.self teruggegeven
+    En bevat _links niet attribuut kinderen
     En wordt in _links geen enkel ander attribuut dan self en partners teruggegeven
     En wordt attribuut _embedded.kinderen teruggegeven
     En wordt in _embedded geen enkel ander attribuut dan kinderen teruggegeven
     En wordt geen enkel ander attribuut dan _links en _embedded teruggegeven
 
-    Als een ingeschreven persoon wordt geraadpleegd met fields=naam&expand=kinderen
-    Dan wordt attribuut naam teruggegeven
+  Scenario: Vragen van specifieke velden met de expand parameter heeft geen invloed op de inhoud van de resource, alleen op de inhoud van de embedded subresource
+    Als een ingeschreven persoon wordt geraadpleegd met expand=kinderen.naam.voornamen
+    Dan bevat elk voorkomen van_embedded.kinderen attribuut naam.voornamen met een waarde
+    En bevat elk voorkomen van_embedded.kinderen attribuut _links.self met een waarde
+    En wordt in elk voorkomen van _embedded.kinderen geen enkel ander attribuut dan naam.voornamen en _links.self teruggegeven
+    En wordt attribuut burgerservicenummer teruggegeven
+    En wordt attribuut naam.voornamen teruggegeven
+    En wordt attribuut naam.geslachtsnaam teruggegeven
+    En wordt attribuut naam.voorvoegsel teruggegeven
+    En wordt attribuut geboorte teruggegeven
     En wordt attribuut _links.self teruggegeven
-    En wordt in _links geen enkel ander attribuut dan self teruggegeven
-    En wordt geen enkel ander attribuut dan naam, _links en _embedded teruggegeven
-    En wordt attribuut _embedded.kinderen teruggegeven
-    En wordt attribuut _embedded.kinderen.burgerservicenummer teruggegeven
-    # wordt op de resource niet gevraagd (fields), maar van de sub-resource wel (expand)
-    En wordt attribuut _embedded.kinderen.geboorte teruggegeven
-    En wordt attribuut _embedded.kinderen._links.ingeschrevenpersonen teruggegeven
+    En wordt attribuut _links.kinderen teruggegeven
+    En wordt in _embedded geen enkel ander attribuut dan kinderen teruggegeven
 
   Scenario: Lege fields parameter geeft alle attributen
     Als een ingeschreven persoon wordt geraadpleegd met fields=
@@ -182,133 +146,44 @@ Functionaliteit: Aanpasbare representatie met de fields parameter
     Als een ingeschreven persoon wordt geraadpleegd met fields=burgerservicenummer,geslachtsaanduiding,bestaatniet
     Dan levert dit een foutmelding
 
+  Scenario: Fields parameter met attribuutnaam met onjuist case
     Als een ingeschreven persoon wordt geraadpleegd met fields=BurgerServiceNummer
     Dan levert dit een foutmelding
 
+  Scenario: Met fields vragen om attributen uit een subresource
     Als een ingeschreven persoon wordt geraadpleegd met expand=kinderen&fields=kinderen.naam
     Dan levert dit een foutmelding
 
-  Scenario: Fields bevat attributen waarvoor de gebruiker niet geautoriseerd is
+  Scenario: Fields vraagt om een groep attributen en de gebruiker is niet geautoriseerd voor al deze attributen
     Gegeven de gebruiker is geautoriseerd voor geboortedatum
-    En de gebruiker is niet geautoriseerd voor geboorteplaats
+    En de gebruiker is niet geautoriseerd voor geboorteplaats en ook niet voor geboorteland
     Als een ingeschreven persoon wordt geraadpleegd met fields=geboorte
     Dan wordt attribuut geboorte.datum teruggegeven
     En is in het antwoord attribuut geboorte.plaats niet aanwezig
+    En is in het antwoord attribuut geboorte.land niet aanwezig
     En wordt attribuut _links.self teruggegeven
     En wordt in _links geen enkel ander attribuut dan self teruggegeven
 
+  Scenario: Fields vraagt specifiek om een gegeven waarvoor deze niet geautoriseerd is
     Gegeven de gebruiker is geautoriseerd voor geboortedatum
     En de gebruiker is niet geautoriseerd voor geboorteplaats
     Als een ingeschreven persoon wordt geraadpleegd met fields=geboorte.datum,geboorte.plaats
     Dan wordt attribuut geboorte.datum teruggegeven
     En is in het antwoord attribuut geboorte.plaats niet aanwezig
+    En is in het antwoord attribuut geboorte.land niet aanwezig
     En wordt attribuut _links.self teruggegeven
     En wordt in _links geen enkel ander attribuut dan self teruggegeven
 
   Scenario: Fields bevat attributen die bij de geraadpleegde persoon geen waarde hebben
     Gegeven de te raadplegen persoon verblijft in het buitenland
-    Als een ingeschreven persoon wordt geraadpleegd met fields=verblijfplaats.postcode,verblijfplaats.huisnummer,verblijfplaats.verblijfBuitenland
-    Dan wordt attribuut verblijfplaats.verblijfBuitenland teruggegeven
-    En is in het antwoord attribuut verblijfplaats.postcode afwezig
-    En is in het antwoord attribuut verblijfplaats.huisnummer afwezig
-
-  Scenario: inOnderzoek wordt altijd teruggegeven wanneer dat van toepassing is
-    Gegeven de te raadplegen persoon heeft geboortedatum in onderzoek (83.10 = 010310)
-    Als een ingeschreven persoon wordt geraadpleegd met fields=geboorte.datum
-    Dan wordt attribuut geboorte.datum teruggegeven
-    En wordt attribuut geboorte.inOnderzoek.datum teruggegeven
-    En is in het antwoord attribuut geboorte.inOnderzoek.plaats afwezig
-    En is in het antwoord attribuut inOnderzoek afwezig
-
-    Gegeven de te raadplegen persoon heeft naam in onderzoek (83.10 = 010200)
-    Als een ingeschreven persoon wordt geraadpleegd met fields=naam
-    Dan is in het antwoord naam.inOnderzoek.voornamen=true
-    En is in het antwoord naam.inOnderzoek.adellijkeTitel_predikaat=true
-    Dan is in het antwoord naam.inOnderzoek.voorvoegsel=true
-    Dan is in het antwoord naam.inOnderzoek.geslachtsnaam=true
-    En is in het antwoord attribuut naam.inOnderzoek.aanduidingNaamgebruik afwezig
-    En is in het antwoord attribuut inOnderzoek afwezig
-
-    Gegeven de te raadplegen persoon heeft naam in onderzoek (83.10 = 010200)
-    Als een ingeschreven persoon wordt geraadpleegd met fields=naam.voornamen,naam.geslachtsnaam
-    Dan is in het antwoord naam.inOnderzoek.voornamen=true
-    En is in het antwoord attribuut naam.inOnderzoek.adellijkeTitel_predikaat afwezig
-    En is in het antwoord attribuut naam.inOnderzoek.voorvoegsel afwezig
-    En is in het antwoord naam.inOnderzoek.geslachtsnaam=true
-    En is in het antwoord attribuut naam.inOnderzoek.aanduidingNaamgebruik afwezig
-    En is in het antwoord attribuut inOnderzoek afwezig
-
-    Gegeven de te raadplegen persoon heeft naam in onderzoek (83.10 = 010200)
-    Als een ingeschreven persoon wordt geraadpleegd met fields=geboorte
-    Dan is in het antwoord attribuut naam.inOnderzoek afwezig
-    En is in het antwoord attribuut geboorte.inOnderzoek afwezig
-    En is in het antwoord attribuut inOnderzoek afwezig
-
-    Gegeven de te raadplegen persoon heeft de hele categorie persoon in onderzoek (83.10 = 010000)
-    Als een ingeschreven persoon wordt geraadpleegd met fields=geboorte
-    Dan is in het antwoord geboorte.inOnderzoek.datum=true
-    En is in het antwoord geboorte.inOnderzoek.plaats=true
-    En is in het antwoord geboorte.inOnderzoek.land=true
-    En is in het antwoord attribuut naam.inOnderzoek afwezig
-    En is in het antwoord attribuut inOnderzoek afwezig
-
-  Scenario: indicatie geheim wordt altijd meegegeven wanneer deze een waarde heeft anders dan 0
-    Gegeven de te raadplegen persoon heeft indicatie geheim "niet aan kerken" (70.10 = 2)
-    Als een ingeschreven persoon wordt geraadpleegd met fields=geslachtsaanduiding
-    Dan wordt attribuut geslachtsaanduiding teruggegeven
-    En wordt attribuut indicatieGeheim teruggegeven
-    En is in het antwoord indicatieGeheim=2
-    En wordt attribuut _links.self teruggegeven
-    En wordt geen enkel ander attribuut dan geslachtsaanduiding, indicatieGeheim en _links.self teruggegeven
-
-    Gegeven de te raadplegen persoon heeft indicatie geheim "geen beperking" (70.10 = 0)
-    Als een ingeschreven persoon wordt geraadpleegd met fields=geslachtsaanduiding
-    Dan wordt attribuut geslachtsaanduiding teruggegeven
-    En is in het antwoord attribuut indicatieGeheim afwezig
-    En wordt attribuut _links.self teruggegeven
-    En wordt geen enkel ander attribuut dan geslachtsaanduiding en _links.self teruggegeven
-
-    Gegeven de te raadplegen persoon heeft indicatie geheim "geen beperking" (70.10 = 0)
-    Als een ingeschreven persoon wordt geraadpleegd met fields=geslachtsaanduiding,indicatieGeheim
-    Dan wordt attribuut geslachtsaanduiding teruggegeven
-    En wordt attribuut indicatieGeheim teruggegeven
-    En is in het antwoord indicatieGeheim=0
-    En wordt attribuut _links.self teruggegeven
-    En wordt geen enkel ander attribuut dan geslachtsaanduiding, indicatieGeheim en _links.self teruggegeven
-
-  Scenario: reden opschorting bijhouding wordt altijd meegegeven wanneer deze een waarde heeft
-    Gegeven de te raadplegen persoon heeft Datum opschorting bijhouding = "20100101"
-    En de te raadplegen persoon heeft Omschrijving reden opschorting bijhouding (67.20) = "E" (emigratie)
-    Als een ingeschreven persoon wordt geraadpleegd met fields=geslachtsaanduiding
-    Dan wordt attribuut geslachtsaanduiding teruggegeven
-    En wordt attribuut datumOpschortingBijhouding teruggegeven
-    En wordt attribuut redenOpschortingBijhouding teruggegeven
-    En is in het antwoord datumOpschortingBijhouding.datum=2010-01-01
-    En is in het antwoord redenOpschortingBijhouding=E
-    En wordt attribuut _links.self teruggegeven
-    En wordt geen enkel ander attribuut dan geslachtsaanduiding, datumOpschortingBijhouding, redenOpschortingBijhouding en _links.self teruggegeven
-
-  Scenario: property en link met dezelfde naam en property wordt gevraagd met fields
-    Gegeven de resource kadastraalonroerendezaken bevat een property stukken
-    En de resource kadastraalonroerendezaken bevat in _links een property stukken
-    En de opgevraagde kadastraalonroerendezaak heeft ten minste één voorkomen voor stukken.
-    Als de kastraalonroerendezaak wordt opgevraagd met fields=stukken
-    Dan bevat het antwoord property stukken
-    En bevat het antwoord geen property _links.stukken
-    En bevat het antwoord property _links.self
-
-  Scenario: property en link met dezelfde naam en link wordt gevraagd met fields
-    Gegeven de resource kadastraalonroerendezaken bevat een property stukken
-    En de resource kadastraalonroerendezaken bevat in _links een property stukken
-    En de opgevraagde kadastraalonroerendezaak heeft ten minste één voorkomen voor stukken.
-    Als de kastraalonroerendezaak wordt opgevraagd met fields=_links.stukken
-    Dan bevat het antwoord geen property stukken
-    En bevat het antwoord property _links.stukken
-    En bevat het antwoord property _links.self
+    Als een ingeschreven persoon wordt geraadpleegd met fields=verblijfplaats.postcode,verblijfplaats.huisnummer
+    Dan wordt attribuut verblijfplaats.adresregel1 teruggegeven
+    En is in het antwoord attribuut verblijfplaats.postcode niet aanwezig
+    En is in het antwoord attribuut verblijfplaats.huisnummer niet aanwezig
 
   Scenario: gebruik fields in een collectie
     Gegeven er zijn twee panden met adresseerbaarObjectIdentificatie=0193010000096628
-    Als panden worden gezocht met adresseerbaarObjectIdentificatie=0193010000096628&fields=identificatie%2Cdocumentdatum
+    Als panden worden gezocht met adresseerbaarObjectIdentificatie=0193010000096628&fields=identificatie&documentdatum
     Dan is het antwoord:
     ```
       {
@@ -341,3 +216,113 @@ Functionaliteit: Aanpasbare representatie met de fields parameter
        }
       }
     ```
+
+
+    Voor sommige API's kan besloten worden extra functionaliteit te bieden bij het invullen van de fields paramter. Bij de API specificaties en/of features is dan aangegeven dat de uitgebreide variant van de fields functionaliteit wordt geborden.
+    Deze functionaliteit maakt het mogelijk velden in groepen te vragen door alleen de naam van de property op te geven, of een deel van het pad, niet het hele pad ervoor. Dit kan nuttig zijn om de lengte van de waarde in fields te beperken.
+
+    Met de fields parameter kan een gevraagd veld worden aangeduid met:
+    - het hele pad naar dat veld, bijvoorbeeld fields=verblijfplaats.datumAanvangAdreshouding.jaar
+    - het laatste deel van het pad naar dat veld, bijvoorbeeld fields=datumAanvangAdreshouding.jaar
+    - alleen de veldnaam, bijvoorbeeld fields=jaar
+
+    Voor elk veld in fields moet dit leiden tot één uniek veld in de resource, ongeacht of dit veld bij de specifiek opgevraagde resource een waarde heeft. Bijvoorbeeld een persoon heeft geboorte.land en overlijden.land, dus is fields=land niet toegestaan. In dat geval wordt een foutmelding teruggegeven. In de foutmelding worden de gevonden velden teruggegeven in invalidParams.detail. Wanneer veel velden zijn gevonden (bijvoorbeeld meer dan 3), dan worden de eerste resultaten (bijv. de eerste 3 gevonden velden) gemeld.
+    Wanneer een veld in fields exact zo voorkomt in de resource, maar ook zo voorkomt als einde van het pad naar een ander veld, dan wordt het veld teruggegeven die exact wordt aangeduid met wat in fields is opgenomen.
+
+    Achtergrond:
+      Gegeven de resource zakelijkgerechtigden kent de volgende velden:
+      """
+      {
+        "identificatie",
+        "aanvangsdatum",
+        "erfpachtCanon": {
+          "soortErfpachtCanon": {
+            "code",
+            "waarde"
+          },
+          "jaarlijksBedrag": {
+            "som",
+            "valuta": {
+              "code",
+              "waarde"
+            }
+          }
+        },
+        "tenaamstelling": {
+          "aandeel": {
+            "noemer",
+            "teller"
+          },
+          "aantekeningen": [
+            {
+              "identificatie": "string"
+            }
+          ],
+          "gezamenlijkAandeel": {
+            "noemer",
+            "teller"
+          }
+        },
+        "persoon": {
+          "identificatie",
+          "omschrijving",
+          "type"
+        },
+        "_links": {
+          "self",
+          "persoon",
+          "betrokkenPartner"
+        }
+      }
+      """
+
+    Scenario: opvragen veld met fields door opgeven exacte veld in resource
+      Als zakelijkgerechtigden wordt gevraagd met fields=aanvangsdatum
+      Dan bevat elk voorkomen van _embedded.zakelijkGerechtigden veld aanvangsdatum met een waarde
+
+    Scenario: opvragen veld met fields door opgeven hele pad naar het veld
+      Als zakelijkgerechtigden wordt gevraagd met fields=tenaamstelling.aandeel.noemer
+      Dan bevat elk voorkomen van _embedded.zakelijkGerechtigden veld tenaamstelling.aandeel.noemer met een waarde
+
+    Scenario: opvragen veld met fields door opgeven laatste deel van het pad naar het veld
+      Als zakelijkgerechtigden wordt gevraagd met fields=aandeel.noemer
+      Dan bevat elk voorkomen van _embedded.zakelijkGerechtigden veld tenaamstelling.aandeel.noemer met een waarde
+
+    Scenario: opvragen veld met fields door opgeven alleen de unieke naam van een veld
+      Als zakelijkgerechtigden wordt gevraagd met fields=aandeel
+      Dan bevat elk voorkomen van _embedded.zakelijkGerechtigden veld tenaamstelling.aandeel.noemer met een waarde
+      Dan bevat elk voorkomen van _embedded.zakelijkGerechtigden veld tenaamstelling.aandeel.teller met een waarde
+
+    Scenario: opvragen veld met fields door opgeven exacte naam veld die ook dieper in de resource voorkomt
+      Gegeven de zakelijkgerechtigden resource bevat een veld identificatie
+      En de zakelijkgerechtigden resource bevat een veld persoon.identificatie
+      Als zakelijkgerechtigden wordt gevraagd met fields=identificatie
+      Dan bevat elk voorkomen van _embedded.zakelijkGerechtigden veld identificatie met een waarde
+      Dan bevat geen enkel voorkomen van _embedded.zakelijkGerechtigden veld persoon.identificatie met een waarde
+
+    Scenario: opvragen veld met fields door opgeven naam veld die meerdere keren in de resource voorkomt
+      Gegeven de zakelijkgerechtigden resource bevat een veld tenaamstelling.aandeel.noemer
+      En de zakelijkgerechtigden resource bevat een veld tenaamstelling.gezamenlijkaandeel.noemer
+      Als zakelijkgerechtigden wordt gevraagd met fields=noemer
+      Dan heeft het antwoord http statuscode 400
+      En bevat het antwoord title met de waarde "Een of meerdere parameters zijn niet correct."
+      En bevat het antwoord invalidParams[0].name met waarde "fields"
+      En bevat het antwoord invalidParams[0].code met waarde "fields"
+      En bevat in het antwoord invalidParams[0].detail de tekst "tenaamstelling.aandeel.noemer"
+      En bevat in het antwoord invalidParams[0].detail de tekst "tenaamstelling.gezamenlijkaandeel.noemer"
+
+    Scenario: property en link met dezelfde naam en property wordt gevraagd met fields
+      Gegeven de zakelijkgerechtigden resource bevat een veld persoon
+      En de zakelijkgerechtigden resource bevat een veld _links.persoon
+      Als zakelijkgerechtigden wordt gevraagd met fields=persoon
+      Dan bevat het antwoord property persoon
+      En bevat het antwoord geen property _links.persoon
+      En bevat het antwoord property _links.self
+
+    Scenario: property en link met dezelfde naam en link wordt gevraagd met fields
+      Gegeven de zakelijkgerechtigden resource bevat een veld persoon
+      En de zakelijkgerechtigden resource bevat een veld _links.persoon
+      Als zakelijkgerechtigden wordt gevraagd met fields=_links.persoon
+      Dan bevat het antwoord property _links.persoon
+      En bevat het antwoord property _links.self
+      En bevat het antwoord geen property persoon

--- a/features/fields.feature
+++ b/features/fields.feature
@@ -96,7 +96,7 @@ Functionaliteit: Aanpasbare representatie met de fields parameter
     En bevat _embedded alleen attribuut kinderen
 
   Scenario: Vragen van specifieke velden met de expand parameter heeft geen invloed op de inhoud van de resource, alleen op de inhoud van de embedded subresource
-    Als een ingeschreven persoon wordt geraadpleegd met expand=kinderen.naam.voornamen
+    Als een ingeschreven persoon wordt geraadpleegd met fields=burgerservicenummer,naam,geboorte&expand=kinderen.naam.voornamen
     Dan bevat elk voorkomen van_embedded.kinderen attribuut naam.voornamen met een waarde
     En bevat elk voorkomen van_embedded.kinderen attribuut _links.self met een waarde
     En bevat elk voorkomen van _embedded.kinderen alleen attributen naam en _links


### PR DESCRIPTION
Mogelijk maken dat sommige Haal Centraal API's (zoals BAG) standaard functionaliteit heeft voor fields, door alleen exacte veldnamen (veld op hoogste niveau in de resource) of volledige paden (voor velden in een groep) te gebruiken.

Andere API's, zoals BRK en BRP, kunnen aanvullende functionaliteit bieden, door velden in groepen ook direct aan te roepen, zoals verblijfplaats.straat vragen met fields=straat

Verder is de fields feature wat opgeschoond en verbeterd