### PR TITLE
verwijderen verwijzing naar testdata.csv uit features

### DIFF
--- a/features/expand.feature
+++ b/features/expand.feature
@@ -38,8 +38,7 @@ Functionaliteit: Automatisch laden van sub-resources
   Wanneer de expand-parameter wordt opgenomen zonder waarde, wordt een foutmelding gegeven.
 
   Achtergrond:
-    Gegeven de registratie ingeschreven personen kent zoals beschreven in testdata.csv
-    En de te raadplegen persoon een actuele partner(partnerschap of huwelijk), ouders en kinderen heeft
+    Gegeven de te raadplegen persoon een actuele partner(partnerschap of huwelijk), ouders en kinderen heeft
     En in onderstaande scenario's wordt de fields-parameter niet gebruikt, tenzij expliciet aangegeven
     En de gebruiker geautoriseerd is voor gevraagde gegevens (sub-resources), tenzij expliciet anders aangegeven
 

--- a/features/wildcard.feature
+++ b/features/wildcard.feature
@@ -16,9 +16,6 @@ Functionaliteit: zoeken met een wildcard wordt ondersteund op enkele parameters
 
   Bij het zoeken op de parameters die een wildcard ondersteunen, moeten er minimaal 2 karakters exclusief de wildcard(s) worden opgegeven.
 
-  Achtergrond:
-    Gegeven de registratie ingeschreven personen kent zoals beschreven in testdata.csv
-
   Scenario: Voor attribuut geslachtsnaam wordt zoeken met een wildcard ondersteund
     Gegeven de registratie ingeschreven personen kent met de geslachtsnaam "Groen", "Groenlo", "Groenink", "Groenen"
     Als ingeschreven personen gezocht worden met ?geboorte__datum=1983-05-26&naam__geslachtsnaam=groen*&naam__voornamen=*frank*


### PR DESCRIPTION
verwijderen van verwijzing naar geautomatiseerd uitvoeren van de features als test met de testdata.csv