### PR TITLE
fix: crs enum niet inline definieren

### DIFF
--- a/api-specificatie/common.yaml
+++ b/api-specificatie/common.yaml
@@ -32,9 +32,7 @@ components:
     contentCrs:
       description: CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel.
       schema:
-        type: string
-        enum:
-          - epsg:28992
+        $ref: '#/components/schemas/CrsEnum'
 # Dit is RD, het enige coordinatenstelsel dat het kadaster nu kan leveren
 # Toevoegen van enumeratiewaarden leidt niet tot breaking changes bij consumers
     X_Pagination_Page:
@@ -138,9 +136,7 @@ components:
       required: false
       description: CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel.
       schema:
-        type: string
-        enum:
-          - epsg:28992
+        $ref: '#/components/schemas/CrsEnum'
 # Dit is RD, het enige coordinatenstelsel dat het kadaster nu (19-05-2020) kan leveren
 # Toevoegen van enumeratiewaarden leidt niet tot breaking changes bij consumers
     acceptCrs:
@@ -150,9 +146,7 @@ components:
       description: Gewenste CRS van de coördinaten in de response.
       schema:
         description: 'CRS van de coördinaten in de response. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel.'
-        type: string
-        enum:
-          - epsg:28992
+        $ref: '#/components/schemas/CrsEnum'
 # Dit is RD, het enige coordinatenstelsel dat het kadaster nu (19-05-2020) kan leveren
 # Toevoegen van enumeratiewaarden leidt niet tot breaking changes bij consumers
   responses:
@@ -738,3 +732,7 @@ components:
       - $ref: "#/components/schemas/Polygon"
       - $ref: "#/components/schemas/MultiPolygon"
       - $ref: "#/components/schemas/GeometryCollection"
+    CrsEnum:
+      type: string
+      enum:
+        - epsg:28992

--- a/api-specificatie/common.yaml
+++ b/api-specificatie/common.yaml
@@ -736,3 +736,4 @@ components:
       type: string
       enum:
         - epsg:28992
+      default: epsg:28992

--- a/api-specificatie/common.yaml
+++ b/api-specificatie/common.yaml
@@ -145,7 +145,6 @@ components:
       required: false
       description: Gewenste CRS van de coördinaten in de response.
       schema:
-        description: 'CRS van de coördinaten in de response. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel.'
         $ref: '#/components/schemas/CrsEnum'
 # Dit is RD, het enige coordinatenstelsel dat het kadaster nu (19-05-2020) kan leveren
 # Toevoegen van enumeratiewaarden leidt niet tot breaking changes bij consumers
@@ -733,6 +732,7 @@ components:
       - $ref: "#/components/schemas/MultiPolygon"
       - $ref: "#/components/schemas/GeometryCollection"
     CrsEnum:
+      description: CRS van geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel.
       type: string
       enum:
         - epsg:28992

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "oas:lint": "spectral lint ./api-specificatie/common.yaml",
+    "oas:lint": "spectral lint ./api-specificatie/common.yaml"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Dit zorgt ervoor dat er meerdere dezelfde crs enum classes wordt gegenereerd tijdens code generatie